### PR TITLE
chaned hosts erb to allow commas in host variables

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'adaptavist/nagios_config'
-version '1.0.1'
+version '1.0.2'
 source 'https://github.com/Adaptavist/puppet-nagios_config.git'
 author 'mhope'
 summary 'nagios_config Module' 

--- a/templates/nagios_host.erb
+++ b/templates/nagios_host.erb
@@ -24,7 +24,7 @@ define host {
         <%- if @custom_variables and @custom_variables != "" -%>
         #custom variables
         <%- @custom_variables.split(',').each do | custom_variable | -%>
-        <%= custom_variable %>
+        <%= custom_variable.gsub('_COMMA_', ',') %>
         <%- end -%>
         <%- end -%>
 }


### PR DESCRIPTION
used a placeholder that is replaced (_COMMA_)